### PR TITLE
[API] `/frames` endpoint, misc docker shit

### DIFF
--- a/Database/Dockerfile
+++ b/Database/Dockerfile
@@ -3,9 +3,8 @@ FROM postgres:latest
 COPY ./docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
 ## mount the folder
 
-ENV POSTGRES_PASSWORD mysecretpassword
-ENV POSTGRES_USER postgres
 ENV POSTGRES_DB postgres
-
+ENV POSTGRES_USER postgres
+ENV POSTGRES_PASSWORD mysecretpassword
 
 EXPOSE 5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,19 @@ services:
       - "5432:5432"
     expose:
       - "5432"
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=mysecretpassword
   salz-api:
     build: salz-api
     depends_on:
       - salz-db
     ports:
       - "8080:8080"
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=mysecretpassword
+      - POSTGRES_PORT=5432
+      - POSTGRES_HOST=salz-db

--- a/salz-api/README.md
+++ b/salz-api/README.md
@@ -1,0 +1,53 @@
+# salz-api
+
+## Endpoints
+
+Endpoints currently implemented
+
+### `/frames/`
+
+`/frames` returns JSON of the following form:
+
+```
+{
+	"frames": [
+		[
+			{
+				"turnid" : 3
+				"playerid" : 5
+				"pos" : [
+					{"x" : 34, "y" : 12}
+					...
+				]
+			}
+			...
+		]
+		...
+	]
+}
+```
+
+i.e., the `frames` value gives a list of list of playercell objects. E.g.: `frames[0]` gives the first frame. `frames[0][2]` gives the third playercell object of that frame (0-indexed). A playercell object has the form
+
+```
+{
+	"turnid" : 123
+	"playerid" : 321
+	"pos" : [
+		{"x" : 1111, "y" : 234}
+		...
+	]
+}
+```
+
+where `pos` lists all cells on the map owned by player `playerid` during frame `turnid`.
+
+#### Query strings
+
+Order of precedence is the order of this listing. E.g., if you pass `numframes` as well as `startframe` and `endframe`, the start/end frame data is evaluated for the response.
+
+- No query strings yields the last 50 frames.
+- if a `startframe` and `endframe` are both provided, returns frames between `startframe` and `endframe` inclusive. 
+	- ex: `/frames?startframe=4&endframe=3`
+- if a `numframes` is provided, provides the last `numframes` frames.
+	- ex: `/frames?numframes=120` : returns the last 120 frames.

--- a/salz-api/run.sh
+++ b/salz-api/run.sh
@@ -1,3 +1,1 @@
-echo "Ghetto way to wait for database: sleeping for 3s before running the api server"
-sleep 5
 pipenv run python salz-api.py

--- a/salz-api/run.sh
+++ b/salz-api/run.sh
@@ -1,3 +1,3 @@
 echo "Ghetto way to wait for database: sleeping for 3s before running the api server"
 sleep 5
-pipenv run python salz_api.py
+pipenv run python salz-api.py

--- a/salz-api/salz-api.py
+++ b/salz-api/salz-api.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, request
 from flask import jsonify
 from flask_cors import CORS
 from datetime import datetime
@@ -63,11 +63,22 @@ db.generate_mapping()
 @app.route('/frames')
 @db_session
 def get_frames():
-    maxFrame = db.select('* FROM get_latest_turnid()')[0]
+    args = request.args
     
-    endFrame = maxFrame - DEFAULT_TURNHISTORY
+    print(args)
 
-    frames = db.select('* from get_frames($endFrame, $maxFrame)')
+    if ('startframe' in args) and ('endframe' in args):
+        startFrame = args['startframe']
+        endFrame = args['endframe']
+    elif ('numframes' in args):
+        endFrame = db.select('* FROM get_latest_turnid()')[0]
+        startFrame = endFrame - args['numframes']
+
+    else:
+        endFrame = db.select('* FROM get_latest_turnid()')[0]
+        startFrame = endFrame - DEFAULT_TURNHISTORY
+
+    frames = db.select('* from get_frames($startFrame, $endFrame)')
 
     # pony not decoding the json, so I guess I gotta.
     jsonframes = [json.loads(x) for x in frames]


### PR DESCRIPTION
- `frames` endpoint now returns JSON in a useful format
- Has support for some query string parameters -- documented in the `salz-api` readme.
- `salz-api` checks for environment variables before defaulting when setting up db connection
- `salz-api` retries db connection on startup, will quit after max retries reached.