### PR TITLE
[salz-viewer] Terminal Viewer map wrap fixed

### DIFF
--- a/salz-core/src/lib/Database.hs
+++ b/salz-core/src/lib/Database.hs
@@ -54,7 +54,7 @@ getSnapshot cs turn = do
     readMap cl = Map.M $ map readCell $  M.catMaybes $ map liftList cl
 
     readCell :: (Int, Int, Int) -> (Map.Coord, Int)
-    readCell (x, y, pid) = (Map.C (toEnum x) (toEnum y), pid)
+    readCell (x, y, pid) = (Map.Coord (toEnum x) (toEnum y), pid)
 
     liftList :: (Maybe Int, Maybe Int, Maybe Int) -> Maybe (Int, Int, Int)
     liftList (Just a, Just b, Just c) = Just (a, b, c)
@@ -152,7 +152,7 @@ saveSnapshot cs turn (Map.M mapLst) = do
 
   let mquery = "INSERT INTO snapshots (turnid, x, y, playerid, generated_at) Values (?,?,?,?,?);"
   time <- getCurrentTime
-  let rows = map (\(Map.C x y, pid) -> (turn, fromEnum x, fromEnum y, pid, time)) mapLst
+  let rows = map (\(Map.Coord x y, pid) -> (turn, fromEnum x, fromEnum y, pid, time)) mapLst
   aExecuteMany conn mquery rows
   aClose conn
   return ()
@@ -172,7 +172,7 @@ saveMoves cs turn moves = do
   return ()
   where
     formatMoves :: Int -> UTCTime -> [(Map.Coord, Int)] -> [(Int, Int, Int, Int, UTCTime)]
-    formatMoves turn time = map (\(Map.C x y, pid) -> (turn, fromEnum x, fromEnum y, pid, time))
+    formatMoves turn time = map (\(Map.Coord x y, pid) -> (turn, fromEnum x, fromEnum y, pid, time))
   
   
 

--- a/salz-core/src/lib/Map.hs
+++ b/salz-core/src/lib/Map.hs
@@ -38,7 +38,7 @@ instance Read MInt where
   readPrec = fmap fromInteger readPrec
 
 instance Enum MInt where
-  toEnum i = I $ toEnum i
+  toEnum i = I $ (toEnum i) `mod` mapSize
   fromEnum (I a) = fromInteger $ a `mod` mapSize
 
 --------------------------------------------------------------------------------

--- a/salz-core/src/lib/Map.hs
+++ b/salz-core/src/lib/Map.hs
@@ -21,16 +21,16 @@ mapSize = 100
 -- MInt
 --------------------------------------------------------------------------------
 
-data MInt = I Integer deriving Eq
+data MInt = MInt Integer deriving Eq
 
 instance Show MInt where
-  show (I a) = show $ a `mod` mapSize
+  show (MInt a) = show $ a `mod` mapSize
 
 instance Num MInt where
-  fromInteger n = I (n `mod` mapSize)
-  (I a) + (I b) = I ((a + b) `mod` mapSize)
-  (I a) - (I b) = I ((a - b) `mod` mapSize)
-  (I a) * (I b) = I ((a * b) `mod` mapSize)
+  fromInteger n = MInt (n `mod` mapSize)
+  (MInt a) + (MInt b) = MInt ((a + b) `mod` mapSize)
+  (MInt a) - (MInt b) = MInt ((a - b) `mod` mapSize)
+  (MInt a) * (MInt b) = MInt ((a * b) `mod` mapSize)
   abs    = undefined  -- make the warnings stop
   signum = undefined
 
@@ -38,23 +38,23 @@ instance Read MInt where
   readPrec = fmap fromInteger readPrec
 
 instance Enum MInt where
-  toEnum i = I $ (toEnum i) `mod` mapSize
-  fromEnum (I a) = fromInteger $ a `mod` mapSize
+  toEnum i = MInt $ (toEnum i) `mod` mapSize
+  fromEnum (MInt a) = fromInteger $ a `mod` mapSize
 
 --------------------------------------------------------------------------------
 -- Coord
 --------------------------------------------------------------------------------
 
-data Coord = C { getX :: MInt, getY :: MInt }  deriving Eq
+data Coord = Coord { getX :: MInt, getY :: MInt }  deriving Eq
 
 instance Show Coord where
-  show (C x y) = show x ++ " " ++ show y
+  show (Coord x y) = show x ++ " " ++ show y
 
 instance Num Coord where
-  (C ax ay) + (C bx by) = C (ax + bx) (ay + by)
-  (C ax ay) - (C bx by) = C (ax - bx) (ay - by)
-  (C ax ay) * (C bx by) = C (ax * bx) (ay * by)
-  fromInteger n = C (I n) (I n)
+  (Coord ax ay) + (Coord bx by) = Coord (ax + bx) (ay + by)
+  (Coord ax ay) - (Coord bx by) = Coord (ax - bx) (ay - by)
+  (Coord ax ay) * (Coord bx by) = Coord (ax * bx) (ay * by)
+  fromInteger n = Coord (MInt n) (MInt n)
   abs    = undefined  -- make the warnings stop
   signum = undefined
 
@@ -62,7 +62,7 @@ instance Read Coord where
   readPrec = do
       x <- readPrec
       y <- readPrec
-      return $ C x y
+      return $ Coord x y
 
 --------------------------------------------------------------------------------
 -- Map
@@ -91,21 +91,21 @@ rotateCoordsAround pivot times = map (((+) pivot). rotateCoord . ((-) pivot))
   where
     degrees :: Float
     degrees = pi*(toEnum times)/2.0
-    rotateCoord (C x y) = C (I $ round ((toEnum $ fromEnum x) * (cos degrees) - (toEnum $ fromEnum y) * (sin degrees)))
-                            (I $ round ((toEnum $ fromEnum x) * (sin degrees) + (toEnum $ fromEnum y) * (cos degrees)))
+    rotateCoord (Coord x y) = Coord (MInt $ round ((toEnum $ fromEnum x) * (cos degrees) - (toEnum $ fromEnum y) * (sin degrees)))
+                            (MInt $ round ((toEnum $ fromEnum x) * (sin degrees) + (toEnum $ fromEnum y) * (cos degrees)))
 
 toCoord :: (Int, Int) -> Coord
-toCoord (x, y) = C (toEnum x) (toEnum y)
+toCoord (x, y) = Coord (toEnum x) (toEnum y)
 
 fromCoord :: Coord -> (Int, Int)
-fromCoord (C x y) = (fromEnum x, fromEnum y)
+fromCoord (Coord x y) = (fromEnum x, fromEnum y)
 
 dist :: Coord -> Coord -> Int
-dist (C ax ay) (C bx by) = max (min (fromEnum mapSize - fromEnum (ax - bx)) (fromEnum (ax - bx)))
+dist (Coord ax ay) (Coord bx by) = max (min (fromEnum mapSize - fromEnum (ax - bx)) (fromEnum (ax - bx)))
                                (min (fromEnum mapSize - fromEnum (ay - by)) (fromEnum (ay - by)))
 
 getRegion :: Map -> ((Int, Int), Int) -> Map
-getRegion (M mlst) ((x, y), radius) = M $ filter (inRegion (C (toEnum x) (toEnum y)) radius) mlst
+getRegion (M mlst) ((x, y), radius) = M $ filter (inRegion (Coord (toEnum x) (toEnum y)) radius) mlst
   where
     inRegion :: Coord -> Int -> (Coord, Int) -> Bool
     inRegion orig radius (x, _) = dist orig x <= radius

--- a/salz-core/src/viewer/EventHandler.hs
+++ b/salz-core/src/viewer/EventHandler.hs
@@ -8,7 +8,6 @@ import qualified Database as DB
 
 import qualified Graphics.Vty as V
 import Brick
-import Data.List
 
 type Name = ()
 data Tick = Tick
@@ -56,10 +55,11 @@ stepTurn vs = vs { VS.turn = (VS.turn vs)+1
 
 
 move :: Char -> VS.ViewerState -> VS.ViewerState
-move 'w' state = state {VS.location = (fst (VS.location state), (snd (VS.location state)) + 5 )}
-move 's' state = state {VS.location = (fst (VS.location state), (snd (VS.location state)) - 5 )}
-move 'a' state = state {VS.location = ((fst (VS.location state)) - 5, snd (VS.location state))}
-move 'd' state = state {VS.location = ((fst (VS.location state)) + 5, snd (VS.location state))}
+move 'w' state = state { VS.location = (VS.location state) + (Map.toCoord (0, 5))}
+move 's' state = state {VS.location = (VS.location state) + (Map.toCoord (0, -5))}
+move 'a' state = state {VS.location = (VS.location state) + (Map.toCoord (-5, 0))}
+move 'd' state = state {VS.location = (VS.location state) + (Map.toCoord (5, 0))}
+move _ state = state
 
 
 appTick :: VS.ViewerState -> VS.ViewerState

--- a/salz-core/src/viewer/Viewer.hs
+++ b/salz-core/src/viewer/Viewer.hs
@@ -51,7 +51,7 @@ loadGame fp = do
   return VS.ViewerState
     { VS.turn = firstTurn
     , VS.play = False
-    , VS.location = Map.C 0 0
+    , VS.location = Map.Coord 0 0
     , VS.dbfilepath = fp
     , VS.board = snap
     , VS.moves = moves

--- a/salz-core/src/viewer/Viewer.hs
+++ b/salz-core/src/viewer/Viewer.hs
@@ -7,6 +7,7 @@ import qualified EventHandler  as EH
 import qualified ViewerState as VS
 import qualified ViewerDraw as VD
 import qualified Database as DB
+import qualified Map as Map
 
 import Brick
 import Brick.BChan
@@ -50,7 +51,7 @@ loadGame fp = do
   return VS.ViewerState
     { VS.turn = firstTurn
     , VS.play = False
-    , VS.location = (0, 0)
+    , VS.location = Map.C 0 0
     , VS.dbfilepath = fp
     , VS.board = snap
     , VS.moves = moves

--- a/salz-core/src/viewer/ViewerDraw.hs
+++ b/salz-core/src/viewer/ViewerDraw.hs
@@ -23,9 +23,9 @@ drawBoard state = withBorderStyle BS.unicodeBold
   $ vBox rows
   where
     map_ = VS.board state
-    (vx, vy) = VS.location state
+    (Map.C vx vy) = VS.location state
     rows = [hBox $ cellsInRow r | r <- [99,98..0]]
-    cellsInRow y = [drawCoord (Map.toCoord (x+vx, y+vy)) | x <- [0..99]]
+    cellsInRow y = [drawCoord $ Map.C ((Map.I x)+vx) ((Map.I y)+vy) | x <- [0..99]]
     drawCoord = drawCell . (Map.getCellAt map_)
 
 drawCell :: Maybe Int -> Widget ()

--- a/salz-core/src/viewer/ViewerDraw.hs
+++ b/salz-core/src/viewer/ViewerDraw.hs
@@ -23,9 +23,9 @@ drawBoard state = withBorderStyle BS.unicodeBold
   $ vBox rows
   where
     map_ = VS.board state
-    (Map.C vx vy) = VS.location state
+    (Map.Coord vx vy) = VS.location state
     rows = [hBox $ cellsInRow r | r <- [99,98..0]]
-    cellsInRow y = [drawCoord $ Map.C ((Map.I x)+vx) ((Map.I y)+vy) | x <- [0..99]]
+    cellsInRow y = [drawCoord $ Map.Coord ((Map.MInt x)+vx) ((Map.MInt y)+vy) | x <- [0..99]]
     drawCoord = drawCell . (Map.getCellAt map_)
 
 drawCell :: Maybe Int -> Widget ()

--- a/salz-core/src/viewer/ViewerState.hs
+++ b/salz-core/src/viewer/ViewerState.hs
@@ -6,7 +6,7 @@ import qualified Map as Map
 data ViewerState = ViewerState
   { turn :: Int
   , play :: Bool
-  , location :: (Int, Int)
+  , location :: Map.Coord
   , dbfilepath :: FilePath
   , board :: Map.Map
   , moves :: [(Int, Int, Int, Int)]


### PR DESCRIPTION
The fix is short, I just changed all of the integer pairs to the coordinate data type.